### PR TITLE
Portfolio deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@
 Contributions, issues, and feature requests are welcome!
 
 
-## Live Demo
-Feel free to check the [issues page](https://github.com/ger619/Portfolio-mobile-version/issues).
-
-
 ## Getting Started
 To get a local copy follow these simple steps:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Portfolio: Mobile Version and Desktop app i.e. responsive
+# Portfolio: Mobile & Desktop App 
 
 > For the second milestone in building your portfolio website, 
 > you will create the mobile website section where you will list your portfolio projects.
@@ -46,27 +46,28 @@ Contributions, issues, and feature requests are welcome!
 
 
 ## Live Demo
-Feel free to check the [issues page](https://ger619.github.io/Portfolio-mobile-version/).
+Feel free to check the [issues page](https://github.com/ger619/Portfolio-mobile-version/issues).
 
 
-## Getting Started Instructions
-To run the portfolio:
+## Getting Started
+To get a local copy follow these simple steps:
 
 - Copy this link https://ger619.github.io/Portfolio-mobile-version/.
 
 - Create a local directory that you want to clone the repository.
 
+
 - Open the command prompt in the created directory.
+
 
 - On the terminal run this command git clone https://github.com/ger619/Portfolio-mobile-version.git.
 
-- Once the files are on your machine, open the folder in Visual Studio Code.
 
 - Go to the repository folder using command prompt cd Portfolio-mobile-version.
- 
+
+
 - Install the dev dependencies for linters run npm install.
 
-- With the files open in Visual Studio Code, press the Go Live button at the bottom of the window to launch the files with Live Server.
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@
 > Feel free to check the [Portfolio-link](https://ger619.github.io/Portfolio-mobile-version/).
 
 
-## Instructions
-
-> Download the ZIP from this location, [link](https://github.com/ger619/Portfolio-mobile-version) or run the git clone [git](https://github.com/ger619/Portfolio-mobile-version.git) branch created_side_bar
-
-> Once the files are on your machine, open the folder in Visual Studio Code.
-
-> With the files open in Visual Studio Code, press the Go Live button at the bottom of the window to launch the files with Live Server.
-
 ## Authors
 
 👤 **David Ger**
@@ -57,8 +49,8 @@ Contributions, issues, and feature requests are welcome!
 Feel free to check the [issues page](https://ger619.github.io/Portfolio-mobile-version/).
 
 
-## Getting Started
-To get a local copy follow these simple steps:
+## Getting Started Instructions
+To run the portfolio:
 
 - Copy this link https://ger619.github.io/Portfolio-mobile-version/.
 
@@ -68,9 +60,13 @@ To get a local copy follow these simple steps:
 
 - On the terminal run this command git clone https://github.com/ger619/Portfolio-mobile-version.git.
 
+- Once the files are on your machine, open the folder in Visual Studio Code.
+
 - Go to the repository folder using command prompt cd Portfolio-mobile-version.
  
 - Install the dev dependencies for linters run npm install.
+
+- With the files open in Visual Studio Code, press the Go Live button at the bottom of the window to launch the files with Live Server.
 
 
 ## Acknowledgments


### PR DESCRIPTION
Deploy website using GitHub Pages.

- Check the online version of your portfolio and make sure that the page works properly.

- Updated the README of your repository to include a link to the online version.

- A Portfolio [link](https://ger619.github.io/Portfolio-mobile-version/) to the PR with changes required for the deployment.